### PR TITLE
Updated to allow specifying Cosmos Db partition key path

### DIFF
--- a/DistributedLeaseManager.AzureCosmosDb/DistributedLeaseCosmosDbOptions.cs
+++ b/DistributedLeaseManager.AzureCosmosDb/DistributedLeaseCosmosDbOptions.cs
@@ -4,5 +4,31 @@ public class DistributedLeaseCosmosDbOptions
 {
     public string DatabaseName { get; set; } = string.Empty;
     public string ContainerName { get; set; } = string.Empty;
-    public string PartitionKeyPath { get; set; } = string.Empty;
+
+    private string _partitionKeyPath = "/pk";
+
+    public string PartitionKeyPath
+    {
+        get => _partitionKeyPath;
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (!value.StartsWith("/"))
+            {
+                throw new ArgumentException("Must start with /.", nameof(value));
+            }
+
+            if (value.LastIndexOf('/') > 0)
+            {
+                throw new ArgumentException("Nested partition key paths are not supported at this time.",
+                    nameof(value));
+            }
+
+            _partitionKeyPath = value;
+        }
+    }
 }

--- a/DistributedLeaseManager.AzureCosmosDb/DistributedLeaseCosmosDbOptions.cs
+++ b/DistributedLeaseManager.AzureCosmosDb/DistributedLeaseCosmosDbOptions.cs
@@ -4,4 +4,5 @@ public class DistributedLeaseCosmosDbOptions
 {
     public string DatabaseName { get; set; } = string.Empty;
     public string ContainerName { get; set; } = string.Empty;
+    public string PartitionKeyPath { get; set; } = string.Empty;
 }

--- a/DistributedLeaseManager.AzureCosmosDb/README.md
+++ b/DistributedLeaseManager.AzureCosmosDb/README.md
@@ -16,12 +16,12 @@ This library contains a lease storage implemented using the Azure Cosmos DB.
 
 1. Register the Distributed Lease Manager in the DI container:
     ```csharp
-    builder.Services.AddCosmosDbDistributedLeaseManager("DatabaseName", "DistributedLeases");
+    builder.Services.AddCosmosDbDistributedLeaseManager("DatabaseName", "DistributedLeases", "/partitionKey");
     ```
 
     or specify the Cosmos DB connection string in case you skipped the first step:
     ```csharp
-    builder.Services.AddCosmosDbDistributedLeaseManager("ConnectionString", "DatabaseName", "DistributedLeases");
+    builder.Services.AddCosmosDbDistributedLeaseManager("ConnectionString", "DatabaseName", "DistributedLeases", "/partitionKey");
     ```
  
 1. Inside your controller/service inject the `IDistributedLeaseManager` and call the `TryAcquireLease` method. Verify if the result was successful - if it was then you can proceed with the operation; otherwise, someone else has acquired the lease:

--- a/DistributedLeaseManager.AzureCosmosDb/README.md
+++ b/DistributedLeaseManager.AzureCosmosDb/README.md
@@ -16,12 +16,12 @@ This library contains a lease storage implemented using the Azure Cosmos DB.
 
 1. Register the Distributed Lease Manager in the DI container:
     ```csharp
-    builder.Services.AddCosmosDbDistributedLeaseManager("DatabaseName", "DistributedLeases", "/partitionKey");
+    builder.Services.AddCosmosDbDistributedLeaseManager("DatabaseName", "DistributedLeases");
     ```
 
     or specify the Cosmos DB connection string in case you skipped the first step:
     ```csharp
-    builder.Services.AddCosmosDbDistributedLeaseManager("ConnectionString", "DatabaseName", "DistributedLeases", "/partitionKey");
+    builder.Services.AddCosmosDbDistributedLeaseManager("ConnectionString", "DatabaseName", "DistributedLeases");
     ```
 
     or utilize one of the overloads that accepts an action in order to also customize the partition key path:

--- a/DistributedLeaseManager.AzureCosmosDb/README.md
+++ b/DistributedLeaseManager.AzureCosmosDb/README.md
@@ -23,6 +23,19 @@ This library contains a lease storage implemented using the Azure Cosmos DB.
     ```csharp
     builder.Services.AddCosmosDbDistributedLeaseManager("ConnectionString", "DatabaseName", "DistributedLeases", "/partitionKey");
     ```
+
+    or utilize one of the overloads that accepts an action in order to also customize the partition key path:
+    ```csharp
+    builder.Services.AddCosmosDbDistributedLeaseManager(
+        "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+        options =>
+        {
+            options.DatabaseName = "DatabaseName";
+            options.ContainerName = "DistributedLeases";
+            options.PartitionKeyPath = "/partitionKey";
+        }); 
+    ```
+   Note: Partition Key Path must start with `/`. Nested partition key paths such as `/my/partitionKey` are not supported.
  
 1. Inside your controller/service inject the `IDistributedLeaseManager` and call the `TryAcquireLease` method. Verify if the result was successful - if it was then you can proceed with the operation; otherwise, someone else has acquired the lease:
     ```csharp

--- a/DistributedLeaseManager.AzureCosmosDb/ServiceCollectionExtensions.cs
+++ b/DistributedLeaseManager.AzureCosmosDb/ServiceCollectionExtensions.cs
@@ -11,31 +11,40 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         string cosmosDbConnectionString,
         string databaseName,
-        string containerName,
-        string partitionKeyPath)
+        string containerName)
     {
         services.TryAddSingleton(new CosmosClient(cosmosDbConnectionString));
 
-        return services.AddCosmosDbDistributedLeaseManager(databaseName, containerName, partitionKeyPath);
+        return services.AddCosmosDbDistributedLeaseManager(databaseName, containerName);
     }
 
     public static IServiceCollection AddCosmosDbDistributedLeaseManager(
         this IServiceCollection services,
         string databaseName,
-        string containerName,
-        string partitionKeyPath)
+        string containerName)
     {
-        if (!partitionKeyPath.StartsWith("/"))
-        {
-            throw new ArgumentException("Must start with /.", nameof(partitionKeyPath));
-        }
-
-        services.Configure<DistributedLeaseCosmosDbOptions>(options =>
+        return services.AddCosmosDbDistributedLeaseManager(options =>
         {
             options.DatabaseName = databaseName;
             options.ContainerName = containerName;
-            options.PartitionKeyPath = partitionKeyPath;
         });
+    }
+
+    public static IServiceCollection AddCosmosDbDistributedLeaseManager(
+        this IServiceCollection services,
+        string cosmosDbConnectionString,
+        Action<DistributedLeaseCosmosDbOptions> optionsConfiguration)
+    {
+        services.TryAddSingleton(new CosmosClient(cosmosDbConnectionString));
+
+        return services.AddCosmosDbDistributedLeaseManager(optionsConfiguration);
+    }
+
+    public static IServiceCollection AddCosmosDbDistributedLeaseManager(
+        this IServiceCollection services,
+        Action<DistributedLeaseCosmosDbOptions> optionsConfiguration)
+    {
+        services.Configure(optionsConfiguration);
 
         services.TryAddScoped<IDistributedLeaseRepository, DistributedLeaseCosmosDb>();
         services.TryAddScoped<IDistributedLeaseManager, DistributedLeaseManager.Core.DistributedLeaseManager>();

--- a/DistributedLeaseManager.AzureCosmosDb/ServiceCollectionExtensions.cs
+++ b/DistributedLeaseManager.AzureCosmosDb/ServiceCollectionExtensions.cs
@@ -11,22 +11,30 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         string cosmosDbConnectionString,
         string databaseName,
-        string containerName)
+        string containerName,
+        string partitionKeyPath)
     {
         services.TryAddSingleton(new CosmosClient(cosmosDbConnectionString));
 
-        return services.AddCosmosDbDistributedLeaseManager(databaseName, containerName);
+        return services.AddCosmosDbDistributedLeaseManager(databaseName, containerName, partitionKeyPath);
     }
 
     public static IServiceCollection AddCosmosDbDistributedLeaseManager(
         this IServiceCollection services,
         string databaseName,
-        string containerName)
+        string containerName,
+        string partitionKeyPath)
     {
+        if (!partitionKeyPath.StartsWith("/"))
+        {
+            throw new ArgumentException("Must start with /.", nameof(partitionKeyPath));
+        }
+
         services.Configure<DistributedLeaseCosmosDbOptions>(options =>
         {
             options.DatabaseName = databaseName;
             options.ContainerName = containerName;
+            options.PartitionKeyPath = partitionKeyPath;
         });
 
         services.TryAddScoped<IDistributedLeaseRepository, DistributedLeaseCosmosDb>();

--- a/DistributedLeaseManager.Example/Program.cs
+++ b/DistributedLeaseManager.Example/Program.cs
@@ -13,8 +13,12 @@ var builder = WebApplication.CreateBuilder(args);
 // See https://learn.microsoft.com/en-us/azure/cosmos-db/emulator
 //builder.Services.AddCosmosDbDistributedLeaseManager(
 //    "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
-//    "DatabaseName",
-//    "DistributedLeases");
+//    options =>
+//    {
+//        options.DatabaseName = "DatabaseName";
+//        options.ContainerName = "DistributedLeases";
+//        options.PartitionKeyPath = "/partitionKey";
+//    });
 
 // The following example uses a SQL Server Express LocalDB
 // See https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/sql-server-express-localdb


### PR DESCRIPTION
This PR is a proposal to allow the partition key to be variable in the same manner as the DatabaseName and ContainerName. In many cases users will not have the partition key as /pk and they should be able to use an alternative value.