### PR TITLE
Updated resource id property of DistributedLease to support string ids

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,8 +11,8 @@
 		<PackageId>$(AssemblyName)</PackageId>
 		<PackageTags>distributed lease lock manager dlm concurrency aspnet</PackageTags>
 
-		<Version>1.1.0</Version>
-		<PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
+		<Version>2.0.0</Version>
+		<PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>
 
 		<Authors>Oleksandr Manyk</Authors>
 		<PackageProjectUrl>https://github.com/f1x3d/DistributedLeaseManager</PackageProjectUrl>

--- a/DistributedLeaseManager.AzureBlobStorage/DistributedLeaseBlobStorage.cs
+++ b/DistributedLeaseManager.AzureBlobStorage/DistributedLeaseBlobStorage.cs
@@ -47,7 +47,7 @@ public class DistributedLeaseBlobStorage : IDistributedLeaseRepository
         }
     }
 
-    public async Task<DistributedLease?> Find(string resourceCategory, Guid resourceId)
+    public async Task<DistributedLease?> Find(string resourceCategory, string resourceId)
     {
         using var blobStream = new MemoryStream();
 
@@ -111,6 +111,6 @@ public class DistributedLeaseBlobStorage : IDistributedLeaseRepository
     private static string GetBlobPath(DistributedLease lease)
         => GetBlobPath(lease.ResourceCategory, lease.ResourceId);
 
-    private static string GetBlobPath(string resourceCategory, Guid resourceId)
+    private static string GetBlobPath(string resourceCategory, string resourceId)
         => $"{resourceCategory}/{resourceId}.json";
 }

--- a/DistributedLeaseManager.Core/DistributedLease.cs
+++ b/DistributedLeaseManager.Core/DistributedLease.cs
@@ -4,7 +4,7 @@ public class DistributedLease
 {
     public const string DefaultResourceCategory = "Default";
 
-    public Guid ResourceId { get; set; }
+    public string ResourceId { get; set; } = string.Empty;
     public string ResourceCategory { get; set; } = DefaultResourceCategory;
     public DateTimeOffset ExpirationTime { get; set; }
     public string ETag { get; set; } = string.Empty;

--- a/DistributedLeaseManager.Core/DistributedLeaseManager.cs
+++ b/DistributedLeaseManager.Core/DistributedLeaseManager.cs
@@ -10,12 +10,11 @@ public class DistributedLeaseManager : IDistributedLeaseManager
             ?? throw new ArgumentNullException(nameof(repository));
     }
 
-    public Task<IDistributedLeaseAcquisitionResult> TryAcquireLease(Guid resourceId, TimeSpan duration)
+    public Task<IDistributedLeaseAcquisitionResult> TryAcquireLease(string resourceId, TimeSpan duration)
         => TryAcquireLease(DistributedLease.DefaultResourceCategory, resourceId, duration);
 
-    public async Task<IDistributedLeaseAcquisitionResult> TryAcquireLease(
-        string resourceCategory,
-        Guid resourceId,
+    public async Task<IDistributedLeaseAcquisitionResult> TryAcquireLease(string resourceCategory,
+        string resourceId,
         TimeSpan duration)
     {
         await _repository.EnsureCreated();

--- a/DistributedLeaseManager.Core/IDistributedLeaseManager.cs
+++ b/DistributedLeaseManager.Core/IDistributedLeaseManager.cs
@@ -2,6 +2,6 @@ namespace DistributedLeaseManager.Core;
 
 public interface IDistributedLeaseManager
 {
-    Task<IDistributedLeaseAcquisitionResult> TryAcquireLease(Guid resourceId, TimeSpan duration);
-    Task<IDistributedLeaseAcquisitionResult> TryAcquireLease(string resourceCategory, Guid resourceId, TimeSpan duration);
+    Task<IDistributedLeaseAcquisitionResult> TryAcquireLease(string resourceId, TimeSpan duration);
+    Task<IDistributedLeaseAcquisitionResult> TryAcquireLease(string resourceCategory, string resourceId, TimeSpan duration);
 }

--- a/DistributedLeaseManager.Core/IDistributedLeaseRepository.cs
+++ b/DistributedLeaseManager.Core/IDistributedLeaseRepository.cs
@@ -3,7 +3,7 @@ namespace DistributedLeaseManager.Core;
 public interface IDistributedLeaseRepository
 {
     Task EnsureCreated();
-    Task<DistributedLease?> Find(string resourceCategory, Guid resourceId);
+    Task<DistributedLease?> Find(string resourceCategory, string resourceId);
     Task<bool> Add(DistributedLease lease);
     Task<bool> Update(DistributedLease lease);
     Task<bool> Remove(DistributedLease lease);

--- a/DistributedLeaseManager.EntityFrameworkCore/DistributedLeaseConfiguration.cs
+++ b/DistributedLeaseManager.EntityFrameworkCore/DistributedLeaseConfiguration.cs
@@ -29,6 +29,10 @@ public class DistributedLeaseConfiguration : IEntityTypeConfiguration<Distribute
             .HasMaxLength(255);
 
         builder
+            .Property(x => x.ResourceId)
+            .HasMaxLength(255);
+
+        builder
             .Property(x => x.ETag)
             .HasMaxLength(36);
 

--- a/DistributedLeaseManager.EntityFrameworkCore/DistributedLeaseEfCore.cs
+++ b/DistributedLeaseManager.EntityFrameworkCore/DistributedLeaseEfCore.cs
@@ -31,7 +31,7 @@ public class DistributedLeaseEfCore : IDistributedLeaseRepository
         }
     }
 
-    public Task<DistributedLease?> Find(string resourceCategory, Guid resourceId)
+    public Task<DistributedLease?> Find(string resourceCategory, string resourceId)
         => _dbContext.Leases.FirstOrDefaultAsync(x =>
             x.ResourceCategory == resourceCategory &&
             x.ResourceId == resourceId);


### PR DESCRIPTION
Updated `DistributedLease` to support using a `string` as an `id` instead of just a `Guid`. 

![image](https://github.com/user-attachments/assets/d8fc1268-5b82-4c45-9577-a509fe94150b)

![image](https://github.com/user-attachments/assets/d80d0c1e-0e94-4dd4-b8d1-82bc1b147399)

![image](https://github.com/user-attachments/assets/e030f760-d1dc-4cac-84b0-9ebd29843ca4)

Resolves #5 